### PR TITLE
(bug) Add engines obj with node version to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "HackStr33tBoys",
   "version": "0.0.1",
   "author": "HackStr33tBoys",
+  "engines": {
+    "node": "6.4.0"
+  },
   "devDependencies": {},
   "dependencies": {
     "bower": "^1.7.9",


### PR DESCRIPTION
Needed for heroku deployment, or else heroku by default uses node v 5 and destructuring does not work