### PR TITLE
(feat) Integrate eventbrite api calls into app. Filter facebook results by date, up to 1 week

### DIFF
--- a/api_handlers/apiPackage.js
+++ b/api_handlers/apiPackage.js
@@ -20,6 +20,7 @@ e_sourceImage JPG/PNG?
 const url = require('url');
 const meetup_api = require('./meetup_api');
 const fb_api = require('./fb_api.js');
+const eventbrite_api = require('./eventbrite_api.js');
 const utils = require('./utils');
 
 var exports = module.exports = {};
@@ -34,6 +35,7 @@ exports.getEvents = function(req, res, cb) {
   const apiCalls = [
     meetup_api.getMeetUpEvents,
     fb_api.getFbEvents
+    //,eventbrite_api.getEventbriteEvents
   ];
 
   utils.asyncMap(apiCalls, function(JSONarray){

--- a/api_handlers/apiPackage.js
+++ b/api_handlers/apiPackage.js
@@ -30,18 +30,15 @@ exports.getEvents = function(req, res, cb) {
 	//FIXME: Substring method for zip won't account for other queries. 
 	const zip = urlObject.query.substring(4);
 
-  //Get facebook events OR meetup events. Comment one or
-  //the other to see results:
-
   //Index of all of the api calls to be handled. 
-  let apiCalls = [meetup_api.getMeetUpEvents, fb_api.getFbEvents];
+  const apiCalls = [
+    meetup_api.getMeetUpEvents,
+    fb_api.getFbEvents
+  ];
 
   utils.asyncMap(apiCalls, function(JSONarray){
     cb(utils.flatten(JSONarray));
   }, zip);
-  
-	//meetup_api.getMeetUpEvents(zip, cb);
-  //fb_api.getFbEvents(zip, cb);
 }
 
 //For testing newly created APIs. 

--- a/api_handlers/apiPackage.js
+++ b/api_handlers/apiPackage.js
@@ -39,7 +39,7 @@ exports.getEvents = function(req, res, cb) {
   ];
 
   utils.asyncMap(apiCalls, function(JSONarray){
-    cb(utils.flatten(JSONarray));
+    cb(utils.shallowFlatten(JSONarray));
   }, zip);
 }
 

--- a/api_handlers/apiPackage.js
+++ b/api_handlers/apiPackage.js
@@ -38,9 +38,7 @@ exports.getEvents = function(req, res, cb) {
     //,eventbrite_api.getEventbriteEvents
   ];
 
-  utils.asyncMap(apiCalls, function(JSONarray){
-    cb(utils.shallowFlatten(JSONarray));
-  }, zip);
+  utils.asyncMap(apiCalls, JSONarray => cb(JSONarray), zip);
 }
 
 //For testing newly created APIs. 

--- a/api_handlers/eventbrite_api.js
+++ b/api_handlers/eventbrite_api.js
@@ -1,6 +1,6 @@
 const request = require('request');
 const utils = require('./utils');
-const { EVENTBRITE_API_KEY} = require('../config')
+const { EVENTBRITE_API_KEY } = require('../config')
 
 // The code is hard to read but I will try to refactor later. 
 ///////////////////////////////////////////////////////////////////////////
@@ -45,7 +45,7 @@ const dataFilter = (parsedJSON) => {
 
 const getEventbriteAddr = (venueArr, filteredData, cb) => { 
   let body = '';
-  let urlPath = `https://www.eventbriteapi.com/v3/batch/?token=${EVENTBRITE_API_KEY}`;
+  const urlPath = `https://www.eventbriteapi.com/v3/batch/?token=${EVENTBRITE_API_KEY}`;
 
   request.post(
     urlPath)
@@ -76,14 +76,17 @@ exports.getEventbriteEvents = (address, cb) => {
 
     getEventbriteAddr(address, filteredData, (address, filteredData) => { //I'll try to refactor
       filteredData.forEach((eventObj, idx) => { //For the address received, need to combine with the array of events. This is where this gets done.
-        let currAddr = JSON.parse(address[idx].body);
-        if (eventObj.e_venue_id===currAddr.id) {
+        const currAddr = JSON.parse(address[idx].body);
+        if (eventObj.e_venue_id === currAddr.id) {
           eventObj.e_location = {
-            geolocation: [handleUndefined(currAddr, 'address', 'longitude'), handleUndefined(currAddr, 'address', 'latitude')],
+            geolocation: [
+              handleUndefined(currAddr, 'address', 'longitude'),
+              handleUndefined(currAddr, 'address', 'latitude')
+            ],
             country: handleUndefined(currAddr, 'address', 'country'),
             city: handleUndefined(currAddr, 'address', 'city'),
             address: handleUndefined(currAddr, 'address', 'address_1'),
-            venue_name: handleUndefined(address[idx], 'body', 'name')
+            venue_name: handleUndefined(address[idx], 'body', 'name'),
           }
         }
       })

--- a/api_handlers/fb_api.js
+++ b/api_handlers/fb_api.js
@@ -6,19 +6,43 @@ const {
   FB_APP_ACCESS_TOKEN: accessToken,
 } = require('../config');
 
-
 module.exports = {};
 
 const handleUndefined = utils.handleUndefined;
 
+//from http://dejanstojanovic.net/jquery-javascript/2015/september/parsing-date-from-facebook-opengraph-api-response-with-javasscript/
+function parseDateString(dateStr) {  
+    const dateDate = dateStr.split("T")[0];  
+    const dateTime = dateStr.split("T")[1].substring(0, 8);  
+    const dateResult = new Date(Date.UTC(  
+        dateDate.split("-")[0], /* Year */  
+        dateDate.split("-")[1], /* Month */  
+        dateDate.split("-")[2], /* Day */  
+        dateTime.split(":")[0], /* Hour */  
+        dateTime.split(":")[1], /* Minute */  
+        dateTime.split(":")[2]  /* Second*/  
+    ));  
+    return dateResult;  
+} 
+
 function formatFbResponse(events, cb) {
-  const responseJSON = events.map((event) => {
+  //filter out events farther away than 1 week
+  const responseJSON = events.filter(event => {
+    const e_date = parseDateString(event.startTime);
+    const today = new Date();
+    const oneWeek = 1000 * 60 * 60 * 24 * 7;
+    return e_date.getTime() - today.getTime() < oneWeek;
+  })
+  .map((event) => {
     return {
       e_title: event.name,
       e_time: event.startTime,
       e_url: `https://www.facebook.com/events/${event.id}/`,
       e_location: {
-        geolocation: [handleUndefined(event, 'venue', 'location', 'lon'), handleUndefined(event, 'venue', 'location', 'lat')],
+        geolocation: [
+          handleUndefined(event, 'venue', 'location', 'lon'), 
+          handleUndefined(event, 'venue', 'location', 'lat')
+        ],
         country: handleUndefined(event, 'venue', 'location', 'country'),
         city: handleUndefined(event, 'venue', 'location', 'city'),
         address: handleUndefined(event, 'venue', 'location', 'street'),
@@ -36,10 +60,12 @@ function formatFbResponse(events, cb) {
 
 module.exports.getFbEvents = function(zip, cb) {
   //The FB events api requires a latitutde and longitude.
-  //geonames is a free api that converts zip codes to lat/lng:
+  //http://www.geonames.org/ is a free api that 
+  //converts zip codes to lat/lng:
   request.get(`http://api.geonames.org/postalCodeSearchJSON?postalcode=${zip}&maxRows=10&username=${GEONAMES_USERNAME}`)
   .on('data', function(data) {
-    const distance = 10000;
+    //distance in meters
+    const distance = 20000;
 
     //information on zip codes is delivered in JSON. One zip code can refer to
     //several places across the world so we filter by country code to get
@@ -47,6 +73,8 @@ module.exports.getFbEvents = function(zip, cb) {
     const loc = JSON.parse('' + data).postalCodes
       .filter(loc => loc.countryCode === 'US')[0];
     const {lat, lng} = loc;
+
+    //https://github.com/tobilg/facebook-events-by-location-core
     const es = new EventSearch({
       lat,
       lng,
@@ -55,23 +83,10 @@ module.exports.getFbEvents = function(zip, cb) {
     });
 
     es.search().then(function (events) {
-      console.log('\nFacebook events:\n');
-      console.log(events.events[0]);
       formatFbResponse(events.events, eventsObj => cb(eventsObj));
     }).catch(error => console.error('Oops... ', JSON.stringify(error)));
   })
   .on('end', function() {
 
   });
-
-  // let body = '';
-  // request.get(`https://api.meetup.com/2/open_events?key=${MEETUP_API_KEY}&sign=true&photo-host=public&zip=${zip}&page=20`)
-  // .on('data', function(data) {
-  //   body += data;
-  // })
-  // .on('end', function() {
-  //   formatMeetupResponse(JSON.parse(body), function(JSONresponse) {
-  //     cb(JSONresponse);
-  //   });
-  // });
 };

--- a/api_handlers/fb_api.js
+++ b/api_handlers/fb_api.js
@@ -69,12 +69,11 @@ module.exports.getFbEvents = function(zip, cb) {
 
     //information on zip codes is delivered in JSON. One zip code can refer to
     //several places across the world so we filter by country code to get
-    //only the US result.
-    const loc = JSON.parse('' + data).postalCodes
+    //only the US result. We access only the latitude/longitude.
+    const {lat, lng} = JSON.parse('' + data).postalCodes
       .filter(loc => loc.countryCode === 'US')[0];
-    const {lat, lng} = loc;
 
-    //https://github.com/tobilg/facebook-events-by-location-core
+    //call the API: https://github.com/tobilg/facebook-events-by-location-core
     const es = new EventSearch({
       lat,
       lng,
@@ -84,7 +83,7 @@ module.exports.getFbEvents = function(zip, cb) {
 
     es.search().then(function (events) {
       formatFbResponse(events.events, eventsObj => cb(eventsObj));
-    }).catch(error => console.error('Oops... ', JSON.stringify(error)));
+    }).catch(err => console.error('Oops... ', JSON.stringify(err)));
   })
   .on('end', function() {
 

--- a/api_handlers/utils.js
+++ b/api_handlers/utils.js
@@ -31,12 +31,4 @@ exports.asyncMap = function(asyncTasks, callback, ...args) {
 };
 
 //For flattening resulting JSON objects out of asyncMap. 
-exports.flatten = function(array) {
-	let result = [];
-	array.forEach(function(JSONarray){
-		JSONarray.forEach(function(JSONobject){
-			result.push(JSONobject);
-		})
-	});
-	return result; 
-};
+exports.shallowFlatten = arr => [].concat(...arr);

--- a/api_handlers/utils.js
+++ b/api_handlers/utils.js
@@ -15,7 +15,7 @@ exports.handleUndefined = function(...properties) {
 
 //For handling multiple asynchronous calls. 
 exports.asyncMap = function(asyncTasks, callback, ...args) {
-	let result = [];
+	const result = [];
 	let taskCount = 0; 
 	for (let i = 0; i < asyncTasks.length; i++) {
 		(function(i){

--- a/api_handlers/utils.js
+++ b/api_handlers/utils.js
@@ -1,5 +1,7 @@
 var exports = module.exports = {};
 
+const shallowFlatten = arr => [].concat(...arr);
+
 //For error handling, as JSON response may have undefined properties.
 exports.handleUndefined = function(...properties) {
   let currentProperty = properties[0];
@@ -23,12 +25,9 @@ exports.asyncMap = function(asyncTasks, callback, ...args) {
 				taskCount++;
 				result[i] = value;
 				if (taskCount === asyncTasks.length){
-					callback(result);
+					callback(shallowFlatten(result));
 				}
 			});
 		})(i);
 	}
 };
-
-//For flattening resulting JSON objects out of asyncMap. 
-exports.shallowFlatten = arr => [].concat(...arr);


### PR DESCRIPTION
The integration of eventbrite is commented out so as to not
use up the limited number of api calls available with the
api key. Uncomment line 38 in apiPackage.js to re-integrate.

Minor refactors in facebook_api.js, eventbrite_api.js, and apiPackage.js.