### PR TITLE
(feat) Category implementations.

### DIFF
--- a/api_handlers/apiPackage.js
+++ b/api_handlers/apiPackage.js
@@ -45,5 +45,6 @@ exports.getEvents = function(req, res, cb) {
 
 //For testing newly created APIs. 
 exports.testApiCall = function(req, res, cb) {
-  funcheapSF_api.getSfEvents(null, cb);
+  meetup_api.getMeetUpEvents(94549, cb);
+  //funcheapSF_api.getSfEvents(null, cb);
 }

--- a/api_handlers/funcheapSf_api/scrape.js
+++ b/api_handlers/funcheapSf_api/scrape.js
@@ -86,6 +86,18 @@ function JSONify() {
 	});
 };
 
+function parseCategories(classString) {
+	return classString.split(' ')
+	.filter(function(htmlClass) {
+		return /^category\-*/.test(htmlClass);
+	})
+	.map(function(category) {
+		var category = category.split('-')
+		category.shift();
+		return category.join(' ')
+	});
+};
+
 //JSON FORMATTING
 function parseHTML(sourcePath, destPath) {
 	//To snag current date for JSON response object. 
@@ -114,7 +126,7 @@ function parseHTML(sourcePath, destPath) {
 				  area: $(this).find('.entry-meta').find('.region').find('.region-child').text()
 				},
 				e_description: null,
-				e_categories: null,
+				e_categories: parseCategories($(this).parent().attr('class')),
 				e_source: 'FunCheapSF',
 				e_sourceImage: null,
 				cost: $(this).find('.entry-meta').find('.cost').text(),


### PR DESCRIPTION
Server/api_handlers - implement follow-up Meetup api request for group category, now under JSON object ‘e_categories’; implement funcheapSf category parser for JSON.

Notes - funcheapSf categories need further parsing, currently very vague.