### PR TITLE
Bug/fixing Facebook

### DIFF
--- a/api_handlers/apiPackage.js
+++ b/api_handlers/apiPackage.js
@@ -35,10 +35,10 @@ exports.getEvents = function(req, res, cb) {
 
   //Index of all of the api calls to be handled. 
   const apiCalls = [
-    seatgeek_api.getSeatGeekEvents
+    seatgeek_api.getSeatGeekEvents,
     //meetup_api.getMeetUpEvents
-    // fb_api.getFbEvents,
-    //eventbrite_api.getEventbriteEvents
+    //fb_api.getFbEvents
+    // eventbrite_api.getEventbriteEvents
   ];
 
   const SFzips = [

--- a/api_handlers/apiPackage.js
+++ b/api_handlers/apiPackage.js
@@ -37,7 +37,7 @@ exports.getEvents = function(req, res, cb) {
   const apiCalls = [
     seatgeek_api.getSeatGeekEvents,
     //meetup_api.getMeetUpEvents
-    //fb_api.getFbEvents
+    fb_api.getFbEvents
     // eventbrite_api.getEventbriteEvents
   ];
 

--- a/api_handlers/apiPackage.js
+++ b/api_handlers/apiPackage.js
@@ -38,7 +38,7 @@ exports.getEvents = function(req, res, cb) {
     seatgeek_api.getSeatGeekEvents,
     //meetup_api.getMeetUpEvents
     fb_api.getFbEvents
-    // eventbrite_api.getEventbriteEvents
+    //eventbrite_api.getEventbriteEvents
   ];
 
   const SFzips = [
@@ -59,9 +59,8 @@ exports.getEvents = function(req, res, cb) {
 
 //For testing newly created APIs. 
 exports.testApiCall = function(req, res, cb) {
-  seatgeek_api.getSeatGeekEvents(94549, (data) => {
-    data = JSON.stringify(data);
-    res.send(data);
-  });
+  seatgeek_api.getSeatGeekEvents(94549, data => 
+    res.send(JSON.stringify(data))
+  );
   //funcheapSF_api.getSfEvents(null, cb);
 }

--- a/api_handlers/fb_api.js
+++ b/api_handlers/fb_api.js
@@ -45,37 +45,59 @@ module.exports.getFbEvents = function(zip, cb) {
   //The FB events api requires a latitutde and longitude.
   //http://www.geonames.org/ is a free api that 
   //converts zip codes to lat/lng:
+
+
+
   request.get(`http://api.geonames.org/postalCodeSearchJSON?postalcode=${ zip }&maxRows=10&username=${ GEONAMES_USERNAME }`)
   .on('data', function(data) {
     /*
-      BUG: sometimes, the zip codes 92122 and 94102 throw a JSON parse error here.
-      Sometimes it doesn't. Trying the demo page at
+      BUG: sometimes, the zip codes 92122 and 94102 and a few others throw a 
+      JSON parse error here. Sometimes they don't. Trying the demo page at
       http://api.geonames.org/postalCodeSearchJSON?postalcode=92122&maxRows=10&username=HackStr33tBoys
       shows a longer JSON string than the error log in the console,
       so either it's being truncated, not delivered correctly, or just
       parsing incorrectly for whatever reason.
+
+      Because of this bug, we use a try-catch block to bypass errors with the
+      geonames api.
     */
 
     //information on zip codes is delivered in JSON. One zip can refer to
     //several places across the world so we filter by country code to get
     //only the US result. We access only the latitude/longitude.
-    const { lat, lng } = JSON.parse('' + data).postalCodes
-      .filter(loc => loc.countryCode === 'US')[0];
+    try {
+      const zipData = '' + data;
+      const jsonErr = 'received incorrect geocodes JSON object';
 
-    //call the API: https://github.com/tobilg/facebook-events-by-location-core
-    const es = new EventSearch({
-      lat,
-      lng,
-      accessToken,
-      distance: 24141,  //15 miles in meters
-      until: oneUnixWeek(),
-    });
 
-    es.search().then(function (events) {
-      formatFbResponse(events.events, eventsObj => cb(eventsObj));
-    }).catch(err => console.error('Oops... ', JSON.stringify(err)));
+      console.log('zipData: ', zipData);
+
+      //we know the api response starts with '{"postalCodes":[{' and ends with
+      //'}]}' so we check for those. Throw error otherwise.
+      if(zipData.slice(0, 17) !== '{"postalCodes":[{') throw jsonErr;
+      if(zipData.slice(-3) !== '}]}') throw jsonErr;
+
+      console.log('in fb api: data: ', ''+data)
+
+      const { lat, lng } = JSON.parse(zipData).postalCodes
+        .filter(loc => loc.countryCode === 'US')[0];
+
+      //call the API: https://github.com/tobilg/facebook-events-by-location-core
+      const es = new EventSearch({
+        lat,
+        lng,
+        accessToken,
+        distance: 24141,  //15 miles in meters
+        until: oneUnixWeek(),
+      });
+
+      es.search().then(function (events) {
+        formatFbResponse(events.events, events => cb(events));
+      }).catch(err => console.error('Oops... ', JSON.stringify(err)));
+    }
+    catch (err) {
+      console.error(err);
+      cb([]);
+    }
   })
-  .on('end', function() {
-
-  });
 };

--- a/api_handlers/fb_api.js
+++ b/api_handlers/fb_api.js
@@ -66,8 +66,7 @@ module.exports.getFbEvents = function(zip, cb) {
       until: oneUnixWeek(),
     });
 
-    es.search().then((fbEvents) => {
-      formatFbResponse(fbEvents.events, cb);
-    }).catch(err => console.error('Oops... ', JSON.stringify(err)));
+    es.search().then(fbEvents => formatFbResponse(fbEvents.events, cb))
+    .catch(err => console.error(JSON.stringify(err)));
   })
 };

--- a/api_handlers/fb_api.js
+++ b/api_handlers/fb_api.js
@@ -42,62 +42,32 @@ function formatFbResponse(events, cb) {
 };
 
 module.exports.getFbEvents = function(zip, cb) {
+  let jsonData = '';
+
   //The FB events api requires a latitutde and longitude.
-  //http://www.geonames.org/ is a free api that 
-  //converts zip codes to lat/lng:
-
-
-
+  //geonames is a free api that can convert zip codes to lat/lng.
+  //Demo: http://api.geonames.org/postalCodeSearchJSON?postalcode=94107&maxRows=10&username=demo
   request.get(`http://api.geonames.org/postalCodeSearchJSON?postalcode=${ zip }&maxRows=10&username=${ GEONAMES_USERNAME }`)
-  .on('data', function(data) {
-    /*
-      BUG: sometimes, the zip codes 92122 and 94102 and a few others throw a 
-      JSON parse error here. Sometimes they don't. Trying the demo page at
-      http://api.geonames.org/postalCodeSearchJSON?postalcode=92122&maxRows=10&username=HackStr33tBoys
-      shows a longer JSON string than the error log in the console,
-      so either it's being truncated, not delivered correctly, or just
-      parsing incorrectly for whatever reason.
-
-      Because of this bug, we use a try-catch block to bypass errors with the
-      geonames api.
-    */
-
+  .on('data', data => jsonData += data)
+  .on('end', function() {
     //information on zip codes is delivered in JSON. One zip can refer to
     //several places across the world so we filter by country code to get
     //only the US result. We access only the latitude/longitude.
-    try {
-      const zipData = '' + data;
-      const jsonErr = 'received incorrect geocodes JSON object';
+    const { lat, lng } = JSON.parse(jsonData).postalCodes
+      .filter(loc => loc.countryCode === 'US')[0];
 
+    //call the FB search API:
+    //https://github.com/tobilg/facebook-events-by-location-core
+    const es = new EventSearch({
+      lat,
+      lng,
+      accessToken,
+      distance: 24141,  //15 miles in meters
+      until: oneUnixWeek(),
+    });
 
-      console.log('zipData: ', zipData);
-
-      //we know the api response starts with '{"postalCodes":[{' and ends with
-      //'}]}' so we check for those. Throw error otherwise.
-      if(zipData.slice(0, 17) !== '{"postalCodes":[{') throw jsonErr;
-      if(zipData.slice(-3) !== '}]}') throw jsonErr;
-
-      console.log('in fb api: data: ', ''+data)
-
-      const { lat, lng } = JSON.parse(zipData).postalCodes
-        .filter(loc => loc.countryCode === 'US')[0];
-
-      //call the API: https://github.com/tobilg/facebook-events-by-location-core
-      const es = new EventSearch({
-        lat,
-        lng,
-        accessToken,
-        distance: 24141,  //15 miles in meters
-        until: oneUnixWeek(),
-      });
-
-      es.search().then(function (events) {
-        formatFbResponse(events.events, events => cb(events));
-      }).catch(err => console.error('Oops... ', JSON.stringify(err)));
-    }
-    catch (err) {
-      console.error(err);
-      cb([]);
-    }
+    es.search().then((fbEvents) => {
+      formatFbResponse(fbEvents.events, cb);
+    }).catch(err => console.error('Oops... ', JSON.stringify(err)));
   })
 };

--- a/api_handlers/fb_api.js
+++ b/api_handlers/fb_api.js
@@ -8,6 +8,7 @@ const {
 
 module.exports = {};
 
+//Return one week from now in Unix time format
 function oneUnixWeek() {
   const now = (new Date()).getTime();
   const oneWeek = now + 1000 * 60 * 60 * 24 * 7;

--- a/api_handlers/utils.js
+++ b/api_handlers/utils.js
@@ -3,7 +3,7 @@ var exports = module.exports = {};
 const NodeGeocoder = require('node-geocoder');
 const { MAPQUEST_API_KEY } = require('../config');
 
-const shallowFlatten = arr => [].concat(...arr).filter(x => x);
+const shallowFlatten = arr => [].concat(...arr);
 
 //For error handling, as JSON response may have undefined properties.
 exports.handleUndefined = function(...properties) {
@@ -28,7 +28,6 @@ exports.asyncMap = function(asyncTasks, callback, ...args) {
         taskCount++;
         result[i] = value;
         if (taskCount === asyncTasks.length){
-          console.log('Result: ', shallowFlatten(result));
           callback(shallowFlatten(result));
         }
       });
@@ -40,7 +39,7 @@ const options = {
   provider: 'mapquest',
   httpAdapter: 'https', // Default 
   apiKey: MAPQUEST_API_KEY, 
-  formatter: null    
+  formatter: null,
 };
 
 exports.geocoder = NodeGeocoder(options);

--- a/api_handlers/utils.js
+++ b/api_handlers/utils.js
@@ -3,7 +3,7 @@ var exports = module.exports = {};
 const NodeGeocoder = require('node-geocoder');
 const { MAPQUEST_API_KEY } = require('../config');
 
-const shallowFlatten = arr => [].concat(...arr);
+const shallowFlatten = arr => [].concat(...arr).filter(x => x);
 
 //For error handling, as JSON response may have undefined properties.
 exports.handleUndefined = function(...properties) {
@@ -28,6 +28,7 @@ exports.asyncMap = function(asyncTasks, callback, ...args) {
         taskCount++;
         result[i] = value;
         if (taskCount === asyncTasks.length){
+          console.log('Result: ', shallowFlatten(result));
           callback(shallowFlatten(result));
         }
       });

--- a/client/eventList/eventList.js
+++ b/client/eventList/eventList.js
@@ -7,7 +7,8 @@ angular.module('greenfield.eventList', ['ngOrderObjectBy'])
   function($scope,  Events, EventOrganizer, EventCache, _) {
   //$scope.img = `assets/meetup-128.png`
 
-  $scope.allEvents = removeDuplicateAndExpiredEvents(Events.savedEvents);
+
+  $scope.allEvents = /*removeDuplicateAndExpiredEvents */(Events.savedEvents);
   $scope.categories = addCategories($scope.allEvents);
   $scope.eventsByDate = '';
   $scope.searchText = '';
@@ -51,6 +52,7 @@ angular.module('greenfield.eventList', ['ngOrderObjectBy'])
   //TODO: Try to implement this on the backend?
   function removeDuplicateAndExpiredEvents(events){
     const eventsObj = {};
+    console.log(events);
 
     //turn eventsObj into a dup-free version of events
     events.forEach((thisEvent, index) => {
@@ -59,7 +61,7 @@ angular.module('greenfield.eventList', ['ngOrderObjectBy'])
       const nextWeek = oneWeekMS();
       const evtTime = new Date(thisEvent.e_time).getTime();
       if(evtTime < now || evtTime > nextWeek) {
-        return;
+        //return;
       }
 
       //if categories is not null
@@ -85,6 +87,8 @@ angular.module('greenfield.eventList', ['ngOrderObjectBy'])
         eventsObj[thisEvent.e_title] = thisEvent;
       }
     });
+
+    console.log(eventsObj);
 
     return _.map(eventsObj, event => event);
   };

--- a/server.js
+++ b/server.js
@@ -1,15 +1,15 @@
 'use strict';
 const express = require('express');
-// const mongoose = require('mongoose');
-// mongoose.Promise = require('q').Promise;
+const mongoose = require('mongoose');
+mongoose.Promise = require('q').Promise;
 const api_handlers = require('./api_handlers/apiPackage');
 const cache = require('./api_handlers/cache');
 const { geocoder } = require('./api_handlers/utils')
 const app = express();
-// mongoose.connect('mongodb://localhost/hsb'); // 
+mongoose.connect('mongodb://localhost/hsb'); // 
 
 const port = process.env.PORT || 8080;
-// 
+
 app.set('port', port);
 app.use(express.static(__dirname + '/'));
 require('./server/config/middleware.js')(app, express);

--- a/server.js
+++ b/server.js
@@ -1,15 +1,15 @@
 'use strict';
 const express = require('express');
-const mongoose = require('mongoose');
-mongoose.Promise = require('q').Promise;
+// const mongoose = require('mongoose');
+// mongoose.Promise = require('q').Promise;
 const api_handlers = require('./api_handlers/apiPackage');
 const cache = require('./api_handlers/cache');
 const { geocoder } = require('./api_handlers/utils')
 const app = express();
-mongoose.connect('mongodb://localhost/hsb'); // 
+// mongoose.connect('mongodb://localhost/hsb'); // 
 
 const port = process.env.PORT || 8080;
-
+// 
 app.set('port', port);
 app.use(express.static(__dirname + '/'));
 require('./server/config/middleware.js')(app, express);


### PR DESCRIPTION
Facebook API is now error-free, so far as I know. JSON objects returned
by geocodes API parse correctly.

Disable duplicate and expired events checking due to error in parsing
dates on Meetup and Seat Geek events objects.